### PR TITLE
Use GtkFileChooserNative over GtkFileChooserDialog

### DIFF
--- a/io.github.dubstar_04.design.json
+++ b/io.github.dubstar_04.design.json
@@ -5,7 +5,6 @@
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.dubstar_04.design",
     "finish-args" : [
-        "--filesystem=home",
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",

--- a/src/Design/fileIO.js
+++ b/src/Design/fileIO.js
@@ -23,7 +23,7 @@ export class FileIO {
     const filter = new Gtk.FileFilter();
     filter.add_pattern('*.dxf');
 
-    const dialog = new Gtk.FileChooserDialog({
+    const dialog = new Gtk.FileChooserNative({
       action: Gtk.FileChooserAction.OPEN,
       filter: filter,
       select_multiple: false,
@@ -31,17 +31,12 @@ export class FileIO {
       title: 'Open',
     });
 
-    dialog.add_button('Cancel', Gtk.ResponseType.CANCEL);
-    dialog.add_button('OK', Gtk.ResponseType.OK);
-
     dialog.show();
     dialog.connect('response', (dialog, response) => {
-      if (response == Gtk.ResponseType.OK) {
+      if (response == Gtk.ResponseType.ACCEPT) {
         const file = dialog.get_file();
-        dialog.destroy();
         this.loadFile(file, window);
       }
-      dialog.destroy();
     });
   }
 
@@ -110,7 +105,7 @@ export class FileIO {
     const filter = new Gtk.FileFilter();
     filter.add_pattern('*.dxf');
 
-    const dialog = new Gtk.FileChooserDialog({
+    const dialog = new Gtk.FileChooserNative({
       action: Gtk.FileChooserAction.SAVE,
       filter: filter,
       select_multiple: false,
@@ -118,18 +113,8 @@ export class FileIO {
       title: 'Save As',
     });
 
-    dialog.add_button('Cancel', Gtk.ResponseType.CANCEL);
-    dialog.add_button('Save', Gtk.ResponseType.ACCEPT);
-
     const name = this.format_filename(window._tabView.get_selected_page().get_title());
     dialog.set_current_name(`${name}.dxf`);
-
-    const filePath = window.get_active_canvas().getFilePath();
-    if (filePath) {
-      const file = Gio.File.new_for_path(filePath);
-      const path = file.get_parent();
-      dialog.set_current_folder(path);
-    }
 
     dialog.show();
     dialog.connect('response', (dialog, response) => {
@@ -152,8 +137,6 @@ export class FileIO {
           page.set_title(fileName);
         }
       }
-
-      dialog.destroy();
     });
   }
 }


### PR DESCRIPTION
Hello there :D

Currently, the app is using GtkFileChooserDialog, which requires explicit access to the system folders. This permission makes GNOME Software say that the app is not secure.

![Captura desde 2023-02-12 00-04-58](https://user-images.githubusercontent.com/76420970/218296057-5f22e272-abe3-4910-8084-8f3b190a820e.png)


GtkFileChooserNative uses FreeDesktop portals, so it does not have full access to all the folders, but rather only the files which it is given permission by the user.

Portals will also handle recent files, folders opened recently by the app, which are very handy features.

This dialog will eventually be deprecated too (in 4.10) by FileDialog (related to #30 ), which uses portals too, but by the moment I think it's better if the app uses as less permissions as possible :)

I will do a small self-review too, to explain some of the things I changed or removed :)