### PR TITLE
Properties window - Ability to edit entities

### DIFF
--- a/src/Design/propertiesWindow.js
+++ b/src/Design/propertiesWindow.js
@@ -125,15 +125,15 @@ export const PropertiesWindow = GObject.registerClass({
           case 'height':
             suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
             suffixWidget.connect('activate', () => {
-              this.propertyManager.setItemProperties('height',suffixWidget.text);
-            });  
-            break;       
+              this.propertyManager.setItemProperties('height', suffixWidget.text);
+            });
+            break;
           case 'string':
             suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
             suffixWidget.connect('activate', () => {
-              this.propertyManager.setItemProperties('string',suffixWidget.text);
-            });   
-            break;              
+              this.propertyManager.setItemProperties('string', suffixWidget.text);
+            });
+            break;
           default:
             suffixWidget = new Gtk.Label({valign: Gtk.Align.CENTER, label: `${value}`});
             break;

--- a/src/Design/propertiesWindow.js
+++ b/src/Design/propertiesWindow.js
@@ -107,10 +107,6 @@ export const PropertiesWindow = GObject.registerClass({
           /*
             case "width":
                 break;
-            case "height":
-                break;
-            case "rotation":
-                break;
             */
           case 'lineWidth':
             suffixWidget = new Gtk.Entry({input_purpose: Gtk.InputPurpose.NUMBER, valign: Gtk.Align.CENTER, text: `${value}`});

--- a/src/Design/propertiesWindow.js
+++ b/src/Design/propertiesWindow.js
@@ -112,24 +112,31 @@ export const PropertiesWindow = GObject.registerClass({
             case "rotation":
                 break;
             */
-          case 'radius':
-            suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
+          case 'lineWidth':
+            suffixWidget = new Gtk.Entry({input_purpose: Gtk.InputPurpose.NUMBER, valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget.connect('activate', () => {
+              this.propertyManager.setItemProperties('lineWidth', suffixWidget.text);
+            });
             break;
-            // case "lineWidth":
-            //     break;
+          case 'radius':
+            suffixWidget = new Gtk.Entry({input_purpose: Gtk.InputPurpose.NUMBER, valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget.connect('activate', () => {
+              this.propertyManager.setItemProperties('radius', suffixWidget.text);
+            });
+            break;
             // case "colour":
             //     suffixWidget = new Gtk.ColorButton({ valign: Gtk.Align.CENTER, 'rgba': this.toRgba(value) });
             //     break;
             // case "layer":
             //    break;
           case 'height':
-            suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget = new Gtk.Entry({input_purpose: Gtk.InputPurpose.NUMBER, valign: Gtk.Align.CENTER, text: `${value}`});
             suffixWidget.connect('activate', () => {
               this.propertyManager.setItemProperties('height', suffixWidget.text);
             });
             break;
           case 'string':
-            suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget = new Gtk.Entry({input_purpose: Gtk.InputPurpose.ALPHA, valign: Gtk.Align.CENTER, text: `${value}`});
             suffixWidget.connect('activate', () => {
               this.propertyManager.setItemProperties('string', suffixWidget.text);
             });

--- a/src/Design/propertiesWindow.js
+++ b/src/Design/propertiesWindow.js
@@ -122,6 +122,18 @@ export const PropertiesWindow = GObject.registerClass({
             //     break;
             // case "layer":
             //    break;
+          case 'height':
+            suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget.connect('activate', () => {
+              this.propertyManager.setItemProperties('height',suffixWidget.text);
+            });  
+            break;       
+          case 'string':
+            suffixWidget = new Gtk.Entry({valign: Gtk.Align.CENTER, text: `${value}`});
+            suffixWidget.connect('activate', () => {
+              this.propertyManager.setItemProperties('string',suffixWidget.text);
+            });   
+            break;              
           default:
             suffixWidget = new Gtk.Label({valign: Gtk.Align.CENTER, label: `${value}`});
             break;


### PR DESCRIPTION
Added properties editing to the following items;

Format
Entity: editable items added

Line: LineWidth
PolyLine: LineWidth
Text: Height, Text
Arc: LineWidth, Radius
Rec: LineWidth

Radius doesn't seem to work for Circle, possibly to do with the way it is drawn? Arc works fine.