### PR TITLE
docs(metainfo): Link to source repo and homepage

### DIFF
--- a/data/io.github.dubstar_04.design.metainfo.xml
+++ b/data/io.github.dubstar_04.design.metainfo.xml
@@ -175,7 +175,8 @@
 			</description>
 		</release>
 	</releases>
-	<url type="homepage">https://github.com/dubstar-04/Design</url>
+	<url type="homepage">https://design-app.readthedocs.io</url>
+	<url type="vcs-browser">https://github.com/dubstar-04/Design</url>
   	<url type="bugtracker">https://github.com/dubstar-04/Design/issues</url>
 	<recommends>
     	<control>keyboard</control>


### PR DESCRIPTION
cf. https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url